### PR TITLE
Visitor tracking via custom activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,21 @@ You can retrieve content either through the Kentico Cloud Delivery SDKs or the K
 For more info about the API, see the [API reference](https://developer.kenticocloud.com/reference).
 
 You can find the Delivery and other SDKs at <https://github.com/Kentico>.
+
+## Visitor activity tracking
+
+In single-page applications you have to use custom activities to track visitor activity. Here's an example how to start tracking visits of About Us page:
+
+1. In Kentico Cloud, select your project.
+2. Navigate to the Development > API keys.
+3. Copy your Project ID.
+4. Open the `public\index.html` file in the sample application folder.
+5. Find function `ket('start', '569030c7-52a5-44f5-a243-c5285b3eb24e');` and replace it's second parameter with your Project ID.
+6. Save the file.
+7. Go back to Kentico Cloud and navigate to Development > Tracking.
+8. Create a new custom activity and copy its codename.
+9. Open the `src\Components\Header.js` file in the sample application folder.
+10. Find `Custom_Activity_Codename` and replace it with the codename you copied.
+11. Save the file.
+
+When you now run the application and visit the About Us page, you should be able to see your visit in Analytics of Kentico Cloud. You can also create a new dynamic segment of people who did your custom activity and see that is not empty. It contains you as an anonymous visitor. You can learn more about creating segments with Kentico Cloud in the [documentation](https://help.kenticocloud.com/contact-tracking-and-content-personalization/segments/creating-segments-of-your-visitors).

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For more info about the API, see the [API reference](https://developer.kenticocl
 
 You can find the Delivery and other SDKs at <https://github.com/Kentico>.
 
-## Tracking visitors and their activity
+## Visitor activity tracking
 
 In single-page applications you have to use custom activities to track visitor activity. Here's an example of how to start tracking visits of About Us page:
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For more info about the API, see the [API reference](https://developer.kenticocl
 
 You can find the Delivery and other SDKs at <https://github.com/Kentico>.
 
-## Visitor activity tracking
+## Tracking visitors and their activity
 
 In single-page applications you have to use custom activities to track visitor activity. Here's an example of how to start tracking visits of About Us page:
 

--- a/README.md
+++ b/README.md
@@ -50,18 +50,20 @@ You can find the Delivery and other SDKs at <https://github.com/Kentico>.
 
 ## Tracking visitors and their activity
 
-In single-page applications you have to use custom activities to track visitor activity. Here's an example of how to start tracking visits of About Us page:
+By default you can see sample visitor data in Kentico Cloud, even if you already feed the single-page application with your own content. Tracking real visitors needs to be set up separately and here's how to.
+
+In single-page applications you have to use custom activities to track visitor activity. This is how you set up tracking visits of About Us page:
 
 1. In Kentico Cloud, select your project.
 2. Navigate to the Development > API keys.
 3. Copy your Project ID.
 4. Open the `public\index.html` file in the sample application folder.
-5. Find function `ket('start', '975bf280-fd91-488c-994c-2f04416e5ee3');` and replace it's second parameter with your Project ID.
+5. Find function call `ket('start', '');` and use your Project ID as its second parameter.
 6. Save the file.
 7. Go back to Kentico Cloud and navigate to Development > Tracking.
 8. Create a new custom activity and copy its codename.
 9. Open the `src\Utilities\ActivityLogging.js` file in the sample application folder.
-10. Find `Custom_Activity_Codename` and replace it with the codename you copied.
+10. Find function call `window.ket('action', '');` and use the codename you copied as its second parameter.
 11. Save the file.
 
 When you now run the application and visit the About Us page, you should be able to see your visit in Analytics of Kentico Cloud. You can also create a new dynamic segment of people who did the custom activity you created and see that the segment is not empty. It should contain you as an anonymous visitor. You can learn more about creating segments with Kentico Cloud in the [documentation](https://help.kenticocloud.com/contact-tracking-and-content-personalization/segments/creating-segments-of-your-visitors).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can find the Delivery and other SDKs at <https://github.com/Kentico>.
 
 ## Visitor activity tracking
 
-In single-page applications you have to use custom activities to track visitor activity. Here's an example how to start tracking visits of About Us page:
+In single-page applications you have to use custom activities to track visitor activity. Here's an example of how to start tracking visits of About Us page:
 
 1. In Kentico Cloud, select your project.
 2. Navigate to the Development > API keys.
@@ -64,4 +64,4 @@ In single-page applications you have to use custom activities to track visitor a
 10. Find `Custom_Activity_Codename` and replace it with the codename you copied.
 11. Save the file.
 
-When you now run the application and visit the About Us page, you should be able to see your visit in Analytics of Kentico Cloud. You can also create a new dynamic segment of people who did your custom activity and see that is not empty. It contains you as an anonymous visitor. You can learn more about creating segments with Kentico Cloud in the [documentation](https://help.kenticocloud.com/contact-tracking-and-content-personalization/segments/creating-segments-of-your-visitors).
+When you now run the application and visit the About Us page, you should be able to see your visit in Analytics of Kentico Cloud. You can also create a new dynamic segment of people who did the custom activity you created and see that the segment is not empty. It should contain you as an anonymous visitor. You can learn more about creating segments with Kentico Cloud in the [documentation](https://help.kenticocloud.com/contact-tracking-and-content-personalization/segments/creating-segments-of-your-visitors).

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ In single-page applications you have to use custom activities to track visitor a
 2. Navigate to the Development > API keys.
 3. Copy your Project ID.
 4. Open the `public\index.html` file in the sample application folder.
-5. Find function `ket('start', '569030c7-52a5-44f5-a243-c5285b3eb24e');` and replace it's second parameter with your Project ID.
+5. Find function `ket('start', '975bf280-fd91-488c-994c-2f04416e5ee3');` and replace it's second parameter with your Project ID.
 6. Save the file.
 7. Go back to Kentico Cloud and navigate to Development > Tracking.
 8. Create a new custom activity and copy its codename.
-9. Open the `src\Components\Header.js` file in the sample application folder.
+9. Open the `src\Utilities\ActivityLogging.js` file in the sample application folder.
 10. Find `Custom_Activity_Codename` and replace it with the codename you copied.
 11. Save the file.
 

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
   <title>Dancing Goat</title>
   <script type="text/javascript">
     !function(){var a='https://engage-ket.kenticocloud.com/js',b=document,c=b.createElement('script'),d=b.getElementsByTagName('script')[0];c.type='text/javascript',c.async=!0,c.defer=!0,c.src=a+'?d='+document.domain,d.parentNode.insertBefore(c,d)}(),window.ket=window.ket||function(){(ket.q=ket.q||[]).push(arguments)};
-    ket('start', '975bf280-fd91-488c-994c-2f04416e5ee3');
+    ket('start', '');
   </script>
 </head>
 

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta charset="UTF-8" />
   <title>Dancing Goat</title>
+  <script type="text/javascript">
+    !function(){var a='https://engage-ket.kenticocloud.com/js',b=document,c=b.createElement('script'),d=b.getElementsByTagName('script')[0];c.type='text/javascript',c.async=!0,c.defer=!0,c.src=a+'?d='+document.domain,d.parentNode.insertBefore(c,d)}(),window.ket=window.ket||function(){(ket.q=ket.q||[]).push(arguments)};
+    ket('start', '569030c7-52a5-44f5-a243-c5285b3eb24e');
+  </script>
 </head>
 
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
   <title>Dancing Goat</title>
   <script type="text/javascript">
     !function(){var a='https://engage-ket.kenticocloud.com/js',b=document,c=b.createElement('script'),d=b.getElementsByTagName('script')[0];c.type='text/javascript',c.async=!0,c.defer=!0,c.src=a+'?d='+document.domain,d.parentNode.insertBefore(c,d)}(),window.ket=window.ket||function(){(ket.q=ket.q||[]).push(arguments)};
-    ket('start', '569030c7-52a5-44f5-a243-c5285b3eb24e');
+    ket('start', '975bf280-fd91-488c-994c-2f04416e5ee3');
   </script>
 </head>
 

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { Link, IndexLink } from 'react-router'
 
+var LogClick = function(){
+      window.ket('action', 'Custom_Activity_Codename');
+}
+
 const Header = () => {
   return (
     <header className="header" role="banner">

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -22,7 +22,7 @@ const Header = () => {
                 <Link to="/articles">Articles</Link>
               </li>
               <li>
-                <Link to="/about">About us</Link>
+                <Link to="/about" onClick={LogClick}>About us</Link>
               </li>
               <li>
                 <Link to="/cafes">Cafes</Link>

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, IndexLink } from 'react-router'
-import { LogClick } from '../Utilities/ActivityLogging'
+import { LogAboutUs } from '../Utilities/ActivityLogging'
 
 const Header = () => {
   return (
@@ -19,7 +19,7 @@ const Header = () => {
                 <Link to="/articles">Articles</Link>
               </li>
               <li>
-                <Link to="/about" onClick={LogClick}>About us</Link>
+                <Link to="/about" onClick={LogAboutUs}>About us</Link>
               </li>
               <li>
                 <Link to="/cafes">Cafes</Link>

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import { Link, IndexLink } from 'react-router'
-
-var LogClick = function(){
-      window.ket('action', 'Custom_Activity_Codename');
-}
+import { LogClick } from '../Utilities/ActivityLogging'
 
 const Header = () => {
   return (

--- a/src/Utilities/ActivityLogging.js
+++ b/src/Utilities/ActivityLogging.js
@@ -1,0 +1,3 @@
+export function LogClick(){
+      window.ket('action', 'Custom_Activity_Codename');
+}

--- a/src/Utilities/ActivityLogging.js
+++ b/src/Utilities/ActivityLogging.js
@@ -1,3 +1,3 @@
-export function LogClick(){
-      window.ket('action', 'Custom_Activity_Codename');
+export function LogAboutUs(){
+      window.ket('action', '');
 }


### PR DESCRIPTION
According to the Engage team, current tracking does not track visits to single-page applications properly. Tracking can be implemented by when you use custom activities. I've added the tracking code, a sample custom activity call and a tutorial that allows you to try how the tracking works.
