### PR TITLE
add recreation for unsubscription subject to allow language change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4478,14 +4478,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4500,20 +4498,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4630,8 +4625,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4643,7 +4637,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4658,7 +4651,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4666,14 +4658,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4692,7 +4682,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4773,8 +4762,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4786,7 +4774,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4908,7 +4895,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/Components/ContactMap.js
+++ b/src/Components/ContactMap.js
@@ -147,7 +147,7 @@ class MapScroller extends Component {
         }
     }
     render() {
-        return <a href="#mapanchor" style={{display: 'None'}}>Map anchor</a>;
+        return <span style={{width: '0px', height: '0px'}}/>;
     }
 }
 

--- a/src/Pages/Contacts.js
+++ b/src/Pages/Contacts.js
@@ -26,7 +26,7 @@ class Contacts extends Component {
 
     componentWillUnmount() {
         CafeStore.removeChangeListener(this.onChange);
-		CafeStore.unsubscribe();
+        CafeStore.unsubscribe();
     }
 
     componentWillReceiveProps(nextProps) {        

--- a/src/Stores/Article.js
+++ b/src/Stores/Article.js
@@ -6,7 +6,7 @@ import { initLanguageCodeObject, defaultLanguage } from '../Utilities/LanguageCo
 
 let articleList = initLanguageCodeObject();
 let articleDetails = initLanguageCodeObject();
-const unsubscribe = new Subject();
+let unsubscribe = new Subject();
 let changeListeners = [];
 
 let notifyChange = () => {
@@ -99,6 +99,7 @@ class ArticleStore {
   unsubscribe() {
     unsubscribe.next();
     unsubscribe.complete();
+    unsubscribe = new Subject();
   }
 
 }

--- a/src/Stores/Brewer.js
+++ b/src/Stores/Brewer.js
@@ -3,7 +3,7 @@ import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { initLanguageCodeObject, defaultLanguage } from '../Utilities/LanguageCodes'
 
-const unsubscribe = new Subject();
+let unsubscribe = new Subject();
 let changeListeners = [];
 let brewers = initLanguageCodeObject();
 
@@ -193,6 +193,7 @@ class BrewerStore {
   unsubscribe() {
     unsubscribe.next();
     unsubscribe.complete();
+    unsubscribe = new Subject();
   }
 
 }

--- a/src/Stores/Cafe.js
+++ b/src/Stores/Cafe.js
@@ -3,7 +3,7 @@ import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { initLanguageCodeObject, defaultLanguage, languageCodes } from '../Utilities/LanguageCodes'
 
-const unsubscribe = new Subject();
+let unsubscribe = new Subject();
 let changeListeners = [];
 let cafes = initLanguageCodeObject();
 let languageInitialized = {};
@@ -81,6 +81,7 @@ class CafeStore {
   unsubscribe() {
     unsubscribe.next();
     unsubscribe.complete();
+    unsubscribe = new Subject();
   }
 
 }

--- a/src/Stores/Coffee.js
+++ b/src/Stores/Coffee.js
@@ -3,7 +3,7 @@ import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { initLanguageCodeObject, defaultLanguage } from '../Utilities/LanguageCodes'
 
-const unsubscribe = new Subject();
+let unsubscribe = new Subject();
 let changeListeners = [];
 let coffees = initLanguageCodeObject();
 let processings = [];
@@ -165,6 +165,7 @@ class CoffeeStore {
   unsubscribe() {
     unsubscribe.next();
     unsubscribe.complete();
+    unsubscribe = new Subject();
   }
 
 }

--- a/src/Stores/Fact.js
+++ b/src/Stores/Fact.js
@@ -3,7 +3,7 @@ import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { initLanguageCodeObject, defaultLanguage } from '../Utilities/LanguageCodes'
 
-const unsubscribe = new Subject();
+let unsubscribe = new Subject();
 let changeListeners = [];
 let facts = initLanguageCodeObject();
 
@@ -66,6 +66,7 @@ class FactStore {
   unsubscribe() {
     unsubscribe.next();
     unsubscribe.complete();
+    unsubscribe = new Subject();
   }
 
 }


### PR DESCRIPTION
Unfortunately while testing https://github.com/Kentico/cloud-sample-app-react/pull/86, I have found out that language switch does not work - it does not load the data.

I did some investigation and found the cause:
It is happening because after the language is switched, subscription for the store is unsubscribed. And then the new language version starts loading - but since Subject is already unsubscribed (because it is using the same store) data are not populated to the store.

There is a simple fix - create a new Subject when the store is unsubscribed.