### PR TITLE
KCL-725 - remove tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,27 +77,6 @@ For more info about the API, see the [API reference](https://developer.kenticocl
 
 You can find the Delivery and other SDKs at <https://github.com/Kentico>.
 
-## Tracking visitors and their activity
-
-By default, you can see sample visitor data in Kentico Cloud, even if you already feed the single-page application with your own content. Tracking real visitors needs to be set up separately and here's how to.
-
-In single-page applications, you have to use custom activities to track visitor activity. This is how you set up tracking visits of About Us page:
-
-1. In Kentico Cloud, choose Project settings from the app menu.
-2. Under Development, choose API keys.
-3. Copy your Project ID.
-4. Open the `public\index.html` file in the sample application folder.
-5. Find function call `ket('start', '');` and use your Project ID as its second parameter.
-6. Save the file.
-7. Go back to your Project settings in Kentico Cloud
-8. Under Development, choose Activity tracking.
-9. Create a new custom activity and copy its codename.
-10. Open the `src\Utilities\ActivityLogging.js` file in the sample application folder.
-11. Find function call `window.ket('action', '');` and use the codename you copied as its second parameter.
-12. Save the file.
-
-When you now run the application and visit the About Us page, you should be able to see your visit in Analytics of Kentico Cloud. You can also create a new dynamic segment of people who did the custom activity you created and see that the segment is not empty. It should contain you as an anonymous visitor. You can learn more about creating segments with Kentico Cloud in the [documentation](https://help.kenticocloud.com/contact-tracking-and-content-personalization/segments/creating-segments-of-your-visitors).
-
 ## Deployment
 
 You can use eg. [surge](http://surge.sh/) to deploy your app live. Check out the step-by-step guide on our [blog](https://kenticocloud.com/blog/3-steps-to-rapidly-deploy-headless-single-page-app).

--- a/public/index.html
+++ b/public/index.html
@@ -6,10 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta charset="UTF-8" />
   <title>Dancing Goat</title>
-  <script type="text/javascript">
-    !function(){var a='https://engage-ket.kenticocloud.com/js',b=document,c=b.createElement('script'),d=b.getElementsByTagName('script')[0];c.type='text/javascript',c.async=!0,c.defer=!0,c.src=a+'?d='+document.domain,d.parentNode.insertBefore(c,d)}(),window.ket=window.ket||function(){(ket.q=ket.q||[]).push(arguments)};
-    ket('start', '');
-  </script>
 </head>
 
 <body>

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -3,7 +3,6 @@ import { translate } from 'react-translate';
 
 import Link from '../Components/LowerCaseUrlLink';
 import { englishCode, spanishCode } from '../Utilities/LanguageCodes';
-import { LogAboutUs } from '../Utilities/ActivityLogging';
 import MessageBox from './MessageBox';
 
 const Header = props => {
@@ -31,16 +30,13 @@ const Header = props => {
               </li>
               {props.language.toLowerCase() === englishCode.toLowerCase() ? (
                 <li>
-                  <Link to={`/${props.language}/about-us`} onClick={LogAboutUs}>
+                  <Link to={`/${props.language}/about-us`}>
                     {props.t('aboutLinkTitle')}
                   </Link>
                 </li>
               ) : props.language.toLowerCase() === spanishCode.toLowerCase() ? (
                 <li>
-                  <Link
-                    to={`/${props.language}/acerca-de`}
-                    onClick={LogAboutUs}
-                  >
+                  <Link to={`/${props.language}/acerca-de`}>
                     {props.t('aboutLinkTitle')}
                   </Link>
                 </li>

--- a/src/Utilities/ActivityLogging.js
+++ b/src/Utilities/ActivityLogging.js
@@ -1,3 +1,0 @@
-export function LogAboutUs() {
-  window.ket('action', '');
-}


### PR DESCRIPTION
Because the Engage part of Kentico Cloud has been removed the Tracking API is no longer supported. This leads to its removal from the Sample App.