### PR TITLE
Add prettierrc file and update list-staged script

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "lint-staged": {
     "{src,examples}/**/*.{js,jsx,json,css}": [
-      "prettier --single-quote --write",
+      "prettier --write",
       "git add"
     ]
   },


### PR DESCRIPTION
### Motivation

<!-- Which issue does this fix? Fixes #`issue number` -->

<!-- If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious? -->

After pulling down the repo and starting to work on an issue, I turned on VS Code's `formatOnSave` option and saw that prettier was using double quotes, and the `lint-staged` script was using single quotes. To fix this, I created the `.prettierrc` file and removed the `--single-quotes` flag from the `lint-staged` command since running the prettier-cli resolves the config. This change will allow editors to use the same config.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Tests are passing
- [x] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults
- [ ] Automated tests have been added

### How to test

<!-- If manual testing is required, what are the steps? -->

1. Switch some quotes to double quotes then commit. The `lint-staged` commit hook should convert them back to single quotes.
2. Try turning on `formatOnSave` with Prettier installed, and it should use single quotes based on the .prettierrc file
