### PR TITLE
Fix article detail page

### DIFF
--- a/src/Pages/Article.js
+++ b/src/Pages/Article.js
@@ -40,7 +40,7 @@ class Article extends Component {
   static getDerivedStateFromProps(nextProps, prevState) {
     if (prevState.language !== nextProps.language) {
       ArticleStore.provideArticle(
-        prevState.match.params.articleId,
+        nextProps.match.params.articleId,
         nextProps.language
       );
       dateFormat.i18n = dateFormats[nextProps.language] || dateFormats[0];


### PR DESCRIPTION
### Motivation

As a part of the #105 merge, I have missed one mistake. That leads to break article detail page.

Router match is propagated by the props object and it is not stored in state.

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docu has been updated (if applicable)
- [ ] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test
See article detail page and try the language switch.